### PR TITLE
passed tflint and checkov

### DIFF
--- a/src/1/main.tf
+++ b/src/1/main.tf
@@ -9,7 +9,7 @@ module "vpc" {
 
 module "vm_instances" {
   for_each = local.instance_params
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=0049a0c47c805c2552e16f7bca2581a7feae0f14"
   env_name       = each.key
   network_id     = module.vpc.network.id
   subnet_zones   = each.value.subnet_zones

--- a/src/1/main.tf
+++ b/src/1/main.tf
@@ -1,5 +1,7 @@
 module "vpc" {
      source      = "./modules/vpc"
+     cloud_id    = var.cloud_id
+     folder_id   = var.folder_id
      env_name = "develop"
      subnets = [
       {zone = "ru-central1-a", cidr = "10.0.1.0/24"},

--- a/src/1/modules/vpc/README.md
+++ b/src/1/modules/vpc/README.md
@@ -1,0 +1,5 @@
+#### Подготовка
+Для инициализации необходим backend.tfvars файл: [пример](backend.tfvars.example)  
+
+#### Инициализация
+`terraform init -backend-config=backend.tfvars`

--- a/src/1/modules/vpc/main.tf
+++ b/src/1/modules/vpc/main.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = "0.129.0"
     }
   }
   required_version = "~>1.8.4"

--- a/src/1/modules/vpc/variables.tf
+++ b/src/1/modules/vpc/variables.tf
@@ -28,7 +28,3 @@ variable "subnets" {
     cidr = string
   }))
 }
-
-variable "bucket_info" {
-  type = map
-}

--- a/src/1/providers.tf
+++ b/src/1/providers.tf
@@ -2,6 +2,11 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = "0.129.0"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2.2.0"
     }
   }
   required_version = "~>1.8.4"

--- a/src/cluster_mysql/main.tf
+++ b/src/cluster_mysql/main.tf
@@ -1,5 +1,7 @@
 module "vpc" {
   source      = "../1/modules/vpc"
+  cloud_id    = var.cloud_id
+  folder_id   = var.folder_id
   env_name = var.env_name
   subnets = [
     {zone = "ru-central1-a", cidr = "10.0.1.0/24"},
@@ -12,6 +14,26 @@ module "mysql" {
   network_id   = module.vpc.network.id
   subnet_id   = module.vpc.subnet_ids[0]
   ha           = true
+  security_group_ids = [yandex_vpc_security_group.mysql_security_group.id]
+}
+
+resource "yandex_vpc_security_group" "mysql_security_group" {
+  name        = "my-db-security-group"
+  description = "Security group for MDB MySQL"
+
+  network_id = module.vpc.network.id
+
+  egress {
+    protocol = "tcp"
+    port    = "3306"
+    v4_cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    protocol = "tcp"
+    port    = "3306"
+    v4_cidr_blocks = ["10.0.0.0/24"]
+  }
 }
 
 variable "env_name" {

--- a/src/cluster_mysql/modules/mysql/main.tf
+++ b/src/cluster_mysql/modules/mysql/main.tf
@@ -12,6 +12,8 @@ resource "yandex_mdb_mysql_cluster" "this" {
   environment = var.mysql_environment
   network_id  = var.network_id
   version = "8.0"
+  security_group_ids = var.security_group_ids
+
 
   resources {
     resource_preset_id = "s2.micro"

--- a/src/cluster_mysql/modules/mysql/variables.tf
+++ b/src/cluster_mysql/modules/mysql/variables.tf
@@ -29,3 +29,8 @@ variable "ha" {  # High-Availability
   type        = bool
   default     = false
 }
+
+variable "security_group_ids" {
+  type        = list(string)
+  description = "https://yandex.cloud/ru/docs/vpc/concepts/security-groups"
+}

--- a/src/cluster_mysql/modules/security_group/main.tf
+++ b/src/cluster_mysql/modules/security_group/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    yandex = {
+      source = "yandex-cloud/yandex"
+      version = "0.129.0"
+    }
+  }
+  required_version = "~>1.8.4"
+}
+
+
+resource "yandex_vpc_security_group" "this" {
+  name        = var.security_group_name
+  description = "Security group for MDB MySQL"
+
+  network_id = var.network_id
+
+  egress {
+    protocol = "tcp"
+    ports    = "3306"
+    v4_cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    protocol = "tcp"
+    ports    = "3306"
+    v4_cidr_blocks = ["10.0.0.0/24"] # использайте необходимый CIDR для вашего случая
+  }
+}
+
+variable security_group_name {
+  type = string
+  default = "undefined"
+}

--- a/src/cluster_mysql/providers.tf
+++ b/src/cluster_mysql/providers.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = "0.129.0"
     }
   }
   required_version = "~>1.8.4"

--- a/src/vault/providers.tf
+++ b/src/vault/providers.tf
@@ -2,6 +2,11 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = "0.130.0"
+    }
+    vault = {
+      source = "hashicorp/vault"
+      version = "~>4.4.0"
     }
   }
   required_version = "~>1.8.4"

--- a/src/yc_s3_bucket/main.tf
+++ b/src/yc_s3_bucket/main.tf
@@ -8,7 +8,7 @@ resource "random_string" "unique_id" {
 }
 
 module "s3" {
-  source = "git::https://github.com/terraform-yc-modules/terraform-yc-s3.git"
+  source = "git::https://github.com/terraform-yc-modules/terraform-yc-s3.git?ref=bb05dc3887e44fe53e103d521bad0894117d25e8"
   bucket_name = "sergio"
   folder_id = var.folder_id
 }

--- a/src/yc_s3_bucket/variables.tf
+++ b/src/yc_s3_bucket/variables.tf
@@ -1,7 +1,9 @@
+# tflint-ignore: terraform_unused_declarations
 variable access_key {
   type    = string
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable secret_key {
   type    = string
 }


### PR DESCRIPTION
### tflint
Во всех проектах возвращает пустую строку
![Screenshot from 2024-10-13 13-25-47](https://github.com/user-attachments/assets/9c18ddb8-5e77-4d6e-9edf-46560578c65b)


### checkov for yc_s3_bucket project:
```
~/Netology/Terraform04/src/yc_s3_bucket$ checkov -d ./
2024-10-13 13:15:28,154 [MainThread  ] [WARNI]  Failed to download module git::https://github.com/terraform-yc-modules/terraform-yc-s3.git?ref=bb05dc3887e44fe53e103d521bad0894117d25e8:None (for external modules, the --download-external-modules flag is required)
[ terraform framework ]: 100%|████████████████████|[4/4], Current File Scanned=versions.tf 
[ secrets framework ]: 100%|████████████████████|[4/4], Current File Scanned=./variables.tf

       _               _              
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V / 
  \___|_| |_|\___|\___|_|\_\___/ \_/  
                                      
By Prisma Cloud | version: 3.2.257 

terraform scan results:

Passed checks: 3, Failed checks: 0, Skipped checks: 0

Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
	PASSED for resource: s3
	File: /main.tf:10-14
	Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-git-url-with-commit-hash-revision
Check: CKV_TF_2: "Ensure Terraform module sources use a tag with a version number"
	PASSED for resource: s3
	File: /main.tf:10-14
	Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-tag
Check: CKV_AWS_41: "Ensure no hard coded AWS access key and secret key exists in provider"
	PASSED for resource: aws.default
	File: /versions.tf:22-29
	Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/aws-policies/secrets-policies/bc-aws-secrets-5

```
### checkov for cluster_mysql project
```
~/Netology/Terraform04/src/cluster_mysql$ checkov -d ./
[ secrets framework ]: 100%|████████████████████|[11/11], Current File Scanned=./modules/security_group/m
[ terraform framework ]: 100%|████████████████████|[15/15], Current File Scanned=variables.tf            

       _               _              
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V / 
  \___|_| |_|\___|\___|_|\_\___/ \_/  
                                      
By Prisma Cloud | version: 3.2.257 

terraform scan results:

Passed checks: 4, Failed checks: 0, Skipped checks: 0

Check: CKV_YC_19: "Ensure security group does not contain allow-all rules."
	PASSED for resource: yandex_vpc_security_group.mysql_security_group
	File: /main.tf:20-37
Check: CKV_YC_1: "Ensure security group is assigned to database cluster."
	PASSED for resource: module.mysql.yandex_mdb_mysql_cluster.this
	File: /modules/mysql/main.tf:10-44
	Calling File: /main.tf:11-18
Check: CKV_YC_12: "Ensure public IP is not assigned to database cluster."
	PASSED for resource: module.mysql.yandex_mdb_mysql_cluster.this
	File: /modules/mysql/main.tf:10-44
	Calling File: /main.tf:11-18
Check: CKV_YC_19: "Ensure security group does not contain allow-all rules."
	PASSED for resource: yandex_vpc_security_group.this
	File: /modules/security_group/main.tf:12-29
```

### checkov for vault project
```
~/Netology/Terraform04/src/vault$ checkov -d ./
[ kubernetes framework ]: 100%|████████████████████|[1/1], Current File Scanned=compose.yml
[ terraform framework ]: 100%|████████████████████|[3/3], Current File Scanned=variables.tf
[ secrets framework ]: 100%|████████████████████|[4/4], Current File Scanned=./variables.tf

       _               _              
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V / 
  \___|_| |_|\___|\___|_|\_\___/ \_/  
                                      
By Prisma Cloud | version: 3.2.257 

secrets scan results:

Passed checks: 0, Failed checks: 0, Skipped checks: 1

Check: CKV_SECRET_6: "Base64 High Entropy String"
	SKIPPED for resource: 24e7451df05ed5cd4cf1041be67c68f8d89d087a
	Suppress comment:  education
	File: /providers.tf:26-27
	Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/secrets-policies/secrets-policy-index/git-secrets-6
```
### checkov for vm with vps project
```
~/Netology/Terraform04/src/1$ checkov -d ./
2024-10-13 13:21:23,549 [MainThread  ] [WARNI]  Failed to download module git::https://github.com/udjin10/yandex_compute_instance.git?ref=0049a0c47c805c2552e16f7bca2581a7feae0f14:None (for external modules, the --download-external-modules flag is required)
[ kubernetes framework ]: 100%|████████████████████|[1/1], Current File Scanned=cloud-init.yml
[ terraform framework ]: 100%|████████████████████|[9/9], Current File Scanned=variables.tf            
[ secrets framework ]: 100%|████████████████████|[10/10], Current File Scanned=./modules/vpc/variables.tf
[ ansible framework ]: 100%|████████████████████|[1/1], Current File Scanned=cloud-init.yml

       _               _              
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V / 
  \___|_| |_|\___|\___|_|\_\___/ \_/  
                                      
By Prisma Cloud | version: 3.2.257 

terraform scan results:

Passed checks: 2, Failed checks: 0, Skipped checks: 0

Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
	PASSED for resource: vm_instances
	File: /main.tf:10-23
	Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-git-url-with-commit-hash-revision
Check: CKV_TF_2: "Ensure Terraform module sources use a tag with a version number"
	PASSED for resource: vm_instances
	File: /main.tf:10-23
	Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-tag
```
## Terraform plan
### yc_s3_bucket
```
  # module.s3.yandex_storage_bucket.this will be created
  + resource "yandex_storage_bucket" "this" {
      + access_key            = "YCAJEb_wd_ilsI1Jxuqo_ueOC"
      + bucket                = "sergio"
      + bucket_domain_name    = (known after apply)
      + default_storage_class = "STANDARD"
      + folder_id             = "b1gnqq5a1oat2u6dk42u"
      + force_destroy         = false
      + id                    = (known after apply)
      + secret_key            = (sensitive value)
      + website_domain        = (known after apply)
      + website_endpoint      = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```
### vault
```
# vault_generic_secret.vault_example2 will be created
  + resource "vault_generic_secret" "vault_example2" {
      + data                = (sensitive value)
      + data_json           = (sensitive value)
      + delete_all_versions = false
      + disable_read        = false
      + id                  = (known after apply)
      + path                = "secret/example2"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

### cluster_mysql
```
# yandex_vpc_security_group.mysql_security_group will be created
  + resource "yandex_vpc_security_group" "mysql_security_group" {
      + created_at  = (known after apply)
      + description = "Security group for MDB MySQL"
      + folder_id   = (known after apply)
      + id          = (known after apply)
      + labels      = (known after apply)
      + name        = "my-db-security-group"
      + network_id  = (known after apply)
      + status      = (known after apply)

      + egress {
          + from_port         = -1
          + id                = (known after apply)
          + labels            = (known after apply)
          + port              = 3306
          + protocol          = "tcp"
          + to_port           = -1
          + v4_cidr_blocks    = [
              + "0.0.0.0/0",
            ]
          + v6_cidr_blocks    = []
            # (3 unchanged attributes hidden)
        }

      + ingress {
          + from_port         = -1
          + id                = (known after apply)
          + labels            = (known after apply)
          + port              = 3306
          + protocol          = "tcp"
          + to_port           = -1
          + v4_cidr_blocks    = [
              + "10.0.0.0/24",
            ]
          + v6_cidr_blocks    = []
            # (3 unchanged attributes hidden)
        }
    }

  # module.mysql.yandex_mdb_mysql_cluster.this will be created
  + resource "yandex_mdb_mysql_cluster" "this" {
      + allow_regeneration_host   = false
      + backup_retain_period_days = (known after apply)
      + created_at                = (known after apply)
      + deletion_protection       = (known after apply)
      + environment               = "PRESTABLE"
      + folder_id                 = (known after apply)
      + health                    = (known after apply)
      + host_group_ids            = (known after apply)
      + id                        = (known after apply)
      + mysql_config              = {
          + "default_authentication_plugin" = "MYSQL_NATIVE_PASSWORD"
          + "innodb_print_all_deadlocks"    = "true"
          + "max_connections"               = "100"
          + "sql_mode"                      = "ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
        }
      + name                      = "example"
      + network_id                = (known after apply)
      + security_group_ids        = (known after apply)
      + status                    = (known after apply)
      + version                   = "8.0"

      + host {
          + assign_public_ip   = false
          + fqdn               = (known after apply)
          + replication_source = (known after apply)
          + subnet_id          = (known after apply)
          + zone               = "ru-central1-a"
        }
      + host {
          + assign_public_ip   = false
          + fqdn               = (known after apply)
          + replication_source = (known after apply)
          + subnet_id          = (known after apply)
          + zone               = "ru-central1-a"
        }

      + resources {
          + disk_size          = 10
          + disk_type_id       = "network-ssd"
          + resource_preset_id = "s2.micro"
        }
    }

  # module.mysql_db_user.yandex_mdb_mysql_database.this will be created
  + resource "yandex_mdb_mysql_database" "this" {
      + cluster_id = (known after apply)
      + id         = (known after apply)
      + name       = "test_db"
    }

  # module.mysql_db_user.yandex_mdb_mysql_user.this will be created
  + resource "yandex_mdb_mysql_user" "this" {
      + authentication_plugin = (known after apply)
      + cluster_id            = (known after apply)
      + global_permissions    = (known after apply)
      + id                    = (known after apply)
      + name                  = "user_dev"
      + password              = (sensitive value)

      + permission {
          + database_name = "test_db"
          + roles         = [
              + "ALL",
              + "INSERT",
            ]
        }
    }

  # module.vpc.yandex_vpc_network.this will be created
  + resource "yandex_vpc_network" "this" {
      + created_at                = (known after apply)
      + default_security_group_id = (known after apply)
      + folder_id                 = (known after apply)
      + id                        = (known after apply)
      + labels                    = (known after apply)
      + name                      = "dev"
      + subnet_ids                = (known after apply)
    }

  # module.vpc.yandex_vpc_subnet.this["ru-central1-a"] will be created
  + resource "yandex_vpc_subnet" "this" {
      + created_at     = (known after apply)
      + folder_id      = (known after apply)
      + id             = (known after apply)
      + labels         = (known after apply)
      + name           = "dev-ru-central1-a"
      + network_id     = (known after apply)
      + v4_cidr_blocks = [
          + "10.0.1.0/24",
        ]
      + v6_cidr_blocks = (known after apply)
      + zone           = "ru-central1-a"
    }

Plan: 6 to add, 0 to change, 0 to destroy.
```
### vm with vps
```
Terraform will perform the following actions:

  # module.vm_instances["analytics"].yandex_compute_instance.vm[0] will be created
  + resource "yandex_compute_instance" "vm" {
      + allow_stopping_for_update = true
      + created_at                = (known after apply)
      + description               = "TODO: description; {{terraform managed}}"
      + folder_id                 = (known after apply)
      + fqdn                      = (known after apply)
      + gpu_cluster_id            = (known after apply)
      + hostname                  = "analytics-analytics-0"
      + id                        = (known after apply)
      + labels                    = {
          + "owner"   = "p.petrov"
          + "project" = "analytics"
        }
      + maintenance_grace_period  = (known after apply)
      + maintenance_policy        = (known after apply)
      + metadata                  = {
          + "serial-port-enable" = "1"
          + "ssh-keys"           = <<-EOT
                ubuntu:ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJp/Zlqh6QDb+YW+anvTCAnpi4igUrwauCXaYTVSfvmN sbitza@gmail.com
            EOT
          + "user-data"          = <<-EOT
                #cloud-config
                users:
                  - name: ubuntu
                    groups: sudo
                    shell: /bin/bash
                    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
                    ssh_authorized_keys:
                      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJp/Zlqh6QDb+YW+anvTCAnpi4igUrwauCXaYTVSfvmN sbitza@gmail.com
                
                package_update: true
                package_upgrade: false
                packages:
                  - vim
                  - nginx
            EOT
        }
      + name                      = "analytics-analytics-0"
      + network_acceleration_type = "standard"
      + platform_id               = "standard-v1"
      + service_account_id        = (known after apply)
      + status                    = (known after apply)
      + zone                      = "ru-central1-a"

      + boot_disk {
          + auto_delete = true
          + device_name = (known after apply)
          + disk_id     = (known after apply)
          + mode        = (known after apply)

          + initialize_params {
              + block_size  = (known after apply)
              + description = (known after apply)
              + image_id    = "fd84lhq77fmk7rffj7g1"
              + name        = (known after apply)
              + size        = 10
              + snapshot_id = (known after apply)
              + type        = "network-hdd"
            }
        }

      + network_interface {
          + index              = (known after apply)
          + ip_address         = (known after apply)
          + ipv4               = true
          + ipv6               = (known after apply)
          + ipv6_address       = (known after apply)
          + mac_address        = (known after apply)
          + nat                = true
          + nat_ip_address     = (known after apply)
          + nat_ip_version     = (known after apply)
          + security_group_ids = (known after apply)
          + subnet_id          = (known after apply)
        }

      + resources {
          + core_fraction = 5
          + cores         = 2
          + memory        = 1
        }

      + scheduling_policy {
          + preemptible = true
        }
    }

  # module.vm_instances["marketing"].yandex_compute_instance.vm[0] will be created
  + resource "yandex_compute_instance" "vm" {
      + allow_stopping_for_update = true
      + created_at                = (known after apply)
      + description               = "TODO: description; {{terraform managed}}"
      + folder_id                 = (known after apply)
      + fqdn                      = (known after apply)
      + gpu_cluster_id            = (known after apply)
      + hostname                  = "marketing-marketing-0"
      + id                        = (known after apply)
      + labels                    = {
          + "owner"   = "i.ivanov"
          + "project" = "marketing"
        }
      + maintenance_grace_period  = (known after apply)
      + maintenance_policy        = (known after apply)
      + metadata                  = {
          + "serial-port-enable" = "1"
          + "ssh-keys"           = <<-EOT
                ubuntu:ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJp/Zlqh6QDb+YW+anvTCAnpi4igUrwauCXaYTVSfvmN sbitza@gmail.com
            EOT
          + "user-data"          = <<-EOT
                #cloud-config
                users:
                  - name: ubuntu
                    groups: sudo
                    shell: /bin/bash
                    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
                    ssh_authorized_keys:
                      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJp/Zlqh6QDb+YW+anvTCAnpi4igUrwauCXaYTVSfvmN sbitza@gmail.com
                
                package_update: true
                package_upgrade: false
                packages:
                  - vim
                  - nginx
            EOT
        }
      + name                      = "marketing-marketing-0"
      + network_acceleration_type = "standard"
      + platform_id               = "standard-v1"
      + service_account_id        = (known after apply)
      + status                    = (known after apply)
      + zone                      = "ru-central1-a"

      + boot_disk {
          + auto_delete = true
          + device_name = (known after apply)
          + disk_id     = (known after apply)
          + mode        = (known after apply)

          + initialize_params {
              + block_size  = (known after apply)
              + description = (known after apply)
              + image_id    = "fd84lhq77fmk7rffj7g1"
              + name        = (known after apply)
              + size        = 10
              + snapshot_id = (known after apply)
              + type        = "network-hdd"
            }
        }

      + network_interface {
          + index              = (known after apply)
          + ip_address         = (known after apply)
          + ipv4               = true
          + ipv6               = (known after apply)
          + ipv6_address       = (known after apply)
          + mac_address        = (known after apply)
          + nat                = true
          + nat_ip_address     = (known after apply)
          + nat_ip_version     = (known after apply)
          + security_group_ids = (known after apply)
          + subnet_id          = (known after apply)
        }

      + resources {
          + core_fraction = 5
          + cores         = 2
          + memory        = 1
        }

      + scheduling_policy {
          + preemptible = true
        }
    }

  # module.vpc.yandex_vpc_network.this will be created
  + resource "yandex_vpc_network" "this" {
      + created_at                = (known after apply)
      + default_security_group_id = (known after apply)
      + folder_id                 = (known after apply)
      + id                        = (known after apply)
      + labels                    = (known after apply)
      + name                      = "develop"
      + subnet_ids                = (known after apply)
    }

  # module.vpc.yandex_vpc_subnet.this["ru-central1-a"] will be created
  + resource "yandex_vpc_subnet" "this" {
      + created_at     = (known after apply)
      + folder_id      = (known after apply)
      + id             = (known after apply)
      + labels         = (known after apply)
      + name           = "develop-ru-central1-a"
      + network_id     = (known after apply)
      + v4_cidr_blocks = [
          + "10.0.1.0/24",
        ]
      + v6_cidr_blocks = (known after apply)
      + zone           = "ru-central1-a"
    }

  # module.vpc.yandex_vpc_subnet.this["ru-central1-b"] will be created
  + resource "yandex_vpc_subnet" "this" {
      + created_at     = (known after apply)
      + folder_id      = (known after apply)
      + id             = (known after apply)
      + labels         = (known after apply)
      + name           = "develop-ru-central1-b"
      + network_id     = (known after apply)
      + v4_cidr_blocks = [
          + "10.0.2.0/24",
        ]
      + v6_cidr_blocks = (known after apply)
      + zone           = "ru-central1-b"
    }

Plan: 5 to add, 0 to change, 0 to destroy.
```